### PR TITLE
Fix OpenSSL detection on Windows

### DIFF
--- a/start.py
+++ b/start.py
@@ -12,7 +12,7 @@ from multiprocessing import Pool
 import itertools
 from typing import Pattern, AnyStr, List
 import curses
-import subprocess
+import ssl
 
 print_ping_error_message = False   # initialize flag variable
 openssl_is_active = False
@@ -726,11 +726,10 @@ def processRegex(cidr: str, include_reg: Pattern[AnyStr], exclude_reg: Pattern[A
 
 # Check if openssl is installed or not
 def has_openssl():
-    try:
-        openssl = subprocess.check_call(["openssl", "version"], stdout=subprocess.PIPE)
+    if ssl.OPENSSL_VERSION:
         return True
-    except:
-        return False
+    else:
+        False
 
 
 # Define CIDR ranges of Cloudflare Network


### PR DESCRIPTION
Update the code that checks for the presence of OpenSSL. This fixes an issue that was specific to Windows, where the code was unable to find the 'openssl' command even though it was installed on the system.